### PR TITLE
Add node position and edge length perturbation/jittering code.

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,6 +108,7 @@
       </div>
     <hr>
     <header>ADVANCED</header>
+    <button title="mirrorMesh" onclick="mirrorMesh()">MIRROR</button><br /><br />
     <input type="checkbox" name="wireframe" onchange="wireFrameMode(this)">Wireframe<br />
     <input type="checkbox" name="webvr" onchange="webVrOn(this)">WebVR<br />
     <div id="webvr"></div>

--- a/js/gis.js
+++ b/js/gis.js
@@ -801,14 +801,40 @@ function jitterEdgeMatrix(matrix,jitterEdgeMultiplierMagnitude){
 	return matrix;
 }
 
+function floatingPointClose(num1,num2,myTolerance) {
+	return(abs(num1-num2) < myTolerance);
+}
+
 function jitterVertexPositionArray(vertices,jitterVertexAbsoluteMagnitude) {
 	// this code randomly perturbs vertex node positions (for the Delaunay)
 	// such that 'nearby' similarly-good MDS results might be found
 	// e.g. symmetric mirrors.
+
+	// Find min and max positions for x and y.
+	// The principle is that no jitters occur along the edges of the maps.
+	// The reason for this is that they otherwise can create very elongated delaunay triangles,
+	//  which creates associated distortions in the rendering.
+	var xPosArray = vertices.map(p => p[0]);
+	var yPosArray = vertices.map(p => p[1]);
+	var xMax = Math.max(...xPosArray);
+	var yMax = Math.max(...yPosArray);
+	var xMin = Math.min(...xPosArray);
+	var yMin = Math.min(...yPosArray);
+
 	for(var v = 0; v < vertices.length; v++) {
-		vertices[v][0] = vertices[v][0] + 2 * (Math.random()-1) * jitterVertexAbsoluteMagnitude;
+		if (
+			!floatingPointClose(xMin,vertices[v][0],jitterVertexAbsoluteMagnitude) &&
+			!floatingPointClose(xMax,vertices[v][0],jitterVertexAbsoluteMagnitude)
+		) {
+			vertices[v][0] = vertices[v][0] + 2 * (Math.random()-1) * jitterVertexAbsoluteMagnitude;
+		};
+		if (
+			!floatingPointClose(yMin,vertices[v][1],jitterVertexAbsoluteMagnitude) &&
+			!floatingPointClose(yMax,vertices[v][1],jitterVertexAbsoluteMagnitude)
+		) {
 		vertices[v][1] = vertices[v][1] + 2 * (Math.random()-1) * jitterVertexAbsoluteMagnitude;
-	};
+	  };
+  };
 	return vertices;
 }
 

--- a/js/gis.js
+++ b/js/gis.js
@@ -811,6 +811,41 @@ function makeMatrix(focus){
 		vertices[y] = [nodes[y].xpos, nodes[y].ypos];
 	}
 
+	// *************
+	// begin distance and position jittering code
+	//
+	// this code randomly perturbs edge distances AND vertex node positions (for the Delaunay)
+	// such that 'nearby' similarly-good MDS results might be found
+	// e.g. symmetric mirrors.
+
+	var jitterEdgeMultiplierMagnitude = 0.01; // fractional maximum jitter multiplier per edge
+	var jitterVertexAbsoluteMagnitude = 1.00; // maximum jitter addition per node x or y coordinate
+
+	var jitterEdgeMatrixMultipliers = numeric.add(
+		1,
+		numeric.add(
+			-1 * jitterEdgeMultiplierMagnitude,
+			numeric.mul(
+				jitterEdgeMultiplierMagnitude,
+				numeric.random([nodes.length,nodes.length])
+			)
+		)
+	);
+	for(var y = 0; y < nodes.length; y++) {
+		for(var x = 0; x < nodes.length; x++) {
+				// do elementwise multiplication -- could be sped up.
+				matrix[x][y] = matrix[x][y] * jitterEdgeMatrixMultipliers[x][y];
+			};
+		};
+
+	for(var v = 0; v < vertices.length; v++) {
+		vertices[v][0] = vertices[v][0] + 2 * (Math.random()-1) * jitterVertexAbsoluteMagnitude;
+		vertices[v][1] = vertices[v][1] + 2 * (Math.random()-1) * jitterVertexAbsoluteMagnitude;
+	};
+	// end distance and position jittering code
+	// *************
+
+
 	//console.log(matrix);
 
 	//calculate Infinity entries with Floyd Warshall algo

--- a/js/gisUI.js
+++ b/js/gisUI.js
@@ -210,3 +210,13 @@ document.getElementById('importImage').onclick = function() {
 		console.log("Made it past loadImage and addMap.")
 		mapImages.push(myfile);
 }
+
+function mirrorMesh() {
+	scene.children.forEach(
+		function(object) {
+			if (object.type === "Mesh") {
+				object.applyMatrix(new THREE.Matrix4().makeScale(-1, 1, 1));
+			}
+		}
+	);
+}


### PR DESCRIPTION
Hi!

Per a conversation with @nicklally, where he suggested (my interpretation here) we add some way to reflect MDS results that could have folded a different-but-equivalent way due to symmetries... I've created a branch and added some code to add minor stochastic perturbations/jittering to both edge distances and vertex positions right before the distance matrix is calculated and triangulation occur.

Presently, the maximum jitter magnitudes are hard-coded in (actuals are randomly drawn from a uniform distribution up to those levels) but they could, if we wanted, be exposed to be edited. I'm not entirely sure this is useful complexity to add to the UI, however.

Please let me know if this works for you! Thanks.